### PR TITLE
Restore stable Nix compatibility

### DIFF
--- a/bin/.any-nix-wrapper
+++ b/bin/.any-nix-wrapper
@@ -5,12 +5,18 @@ fns () {
     which_shell="$1"
     shift
     pos=0
+
+    subcommand=shell
+    if nix --version | grep -q ' 2\.[0-3][^0-9]'; then
+	subcommand=run
+    fi
+
     for arg in "$@"; do
         if [[ $pos != 0 ]]; then
             pos=$((pos-1))
         elif [[ $arg == -* ]]; then
             if [[ $arg == -c ]] || [[ $arg == --command ]]; then
-                command nix shell "$@"
+                command nix "$subcommand" "$@"
                 return
             elif [[ $arg == --arg ]] || [[ $arg == --argstr ]]; then
                 pos=2
@@ -27,6 +33,6 @@ fns () {
     if [[ -n $name ]] && [[ $name != shell ]]; then
         pkgs+=" "$name
     fi
-    env ANY_NIX_SHELL_PKGS="$pkgs" IN_NIX_RUN=1 nix shell "$@" --command $which_shell
+    env ANY_NIX_SHELL_PKGS="$pkgs" IN_NIX_RUN=1 nix "$subcommand" "$@" --command $which_shell
 }
 fns "$@"


### PR DESCRIPTION
Stable Nix doesn't have nix shell, which means the most recent update
broke any-nix-shell for people using the defaults.

Here, I've added a simple version check to restore the old behaviour
on Nix versions that don't have nix shell.