### PR TITLE
Support `nix run` and drop support for `nix shell`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,84 @@
 # any-nix-shell
-`fish` and `zsh` support for the `nix shell` and `nix-shell` environments of the Nix package manager.
+
+`fish` and `zsh` support for the `nix run` and `nix-shell` environments of the Nix package manager.
 
 Features:
 
-  * When entering a `nix shell` or `nix-shell` environment, the shell stays the same.
-  * Inside those environments, your prompt prints the loaded packages to the right.
-  * Alternatively, print that information by executing: `nix-shell-info`
-  * `nix-shell --command` or the like still execute inside `bash`, such that scripts don't break.
+* When entering a `nix run` or `nix-shell` environment, the shell stays the same.
+* Inside those environments, your prompt prints the loaded packages to the right.
+* Alternatively, print that information by executing: `nix-shell-info`
+* `nix-shell --command` or the like still execute inside `bash`, such that scripts don't break.
 
-# Installation
+## Installation
+
 any-nix-shell can currently be installed from the official `nixos-unstable` channel
 ([Link 1](https://www.reddit.com/r/NixOS/comments/7p83y4/install_a_package_from_unstable_while_running/), [Link 2](https://stackoverflow.com/questions/41230430/how-do-i-upgrade-my-system-to-nixos-unstable)).
 If you don't know how to do that, you can alternatively execute
 
-```
+```shell
 nix-env -i any-nix-shell -f https://github.com/NixOS/nixpkgs/archive/master.tar.gz
 ```
 
 which installs `any-nix-shell` into your user environment.
 
-# Enabling
+## Enabling
 
 In the following we describe how to enable the `any-nix-shell` plugin
 for your user.
 This differs slightly between `fish` and `zsh`.
 
-## `fish`
+### `fish`
 
 Add the following to your *~/.config/fish/config.fish*.
 Create it if it doesn't exist.
 
-```
+```fish
 any-nix-shell fish --info-right | source
 ```
 
-## `zsh`
+### `zsh`
 
 Add the following to your *~/.zshrc*.
 Create it if it doesn't exist.
 
-```
+```zsh
 any-nix-shell zsh --info-right | source /dev/stdin
 ```
 
-# System-wide enabling on NixOS
+## System-wide enabling on NixOS
+
 Alternatively the `any-nix-shell` plugin can be enabled system-wide.
 This enables it for every user.
 To do so, add the following to your configuration (*/etc/nixos/configuration.nix*).
 
-## `fish`
+### `fish`
 
-```
+```nix
   programs.fish.enable = true;
   programs.fish.promptInit = ''
     any-nix-shell fish --info-right | source
   '';
 ```
 
-## `zsh`
+### `zsh`
 
-```
+```nix
   programs.zsh.enable = true;
   programs.zsh.promptInit = ''
     any-nix-shell zsh --info-right | source /dev/stdin
   '';
 ```
 
-## `zsh` with home-manager
+### `zsh` with home-manager
 
-```
+```nix
   programs.zsh.enable = true;
   programs.zsh.initExtra = ''
     any-nix-shell zsh --info-right | source /dev/stdin
   '';
 ```
 
-# Customization
+## Customization
 
 The `any-nix-shell` command (which is used for enabling the plugin in a specific shell) **optionally** takes any of the following flags:
 

--- a/bin/.any-nix-wrapper
+++ b/bin/.any-nix-wrapper
@@ -4,11 +4,13 @@ fns () {
     pkgs=$ANY_NIX_SHELL_PKGS
     which_shell="$1"
     shift
+    subcommand="$1"
+    shift
     pos=0
 
-    subcommand=shell
-    if nix --version | grep -q ' 2\.[0-3][^0-9]'; then
-	subcommand=run
+    # `nix run` only launched a shell from Nix 2.0.* to 2.3.*
+    if nix --version | grep -vq ' 2\.[0-3][^0-9]'; then
+        exec nix "$subcommand" "$@"
     fi
 
     for arg in "$@"; do
@@ -16,8 +18,7 @@ fns () {
             pos=$((pos-1))
         elif [[ $arg == -* ]]; then
             if [[ $arg == -c ]] || [[ $arg == --command ]]; then
-                command nix "$subcommand" "$@"
-                return
+                exec nix "$subcommand" "$@"
             elif [[ $arg == --arg ]] || [[ $arg == --argstr ]]; then
                 pos=2
             elif [[ $arg == -f ]] || [[ $arg == --file ]] \
@@ -33,6 +34,6 @@ fns () {
     if [[ -n $name ]] && [[ $name != shell ]]; then
         pkgs+=" "$name
     fi
-    env ANY_NIX_SHELL_PKGS="$pkgs" IN_NIX_RUN=1 nix "$subcommand" "$@" --command $which_shell
+    exec env ANY_NIX_SHELL_PKGS="$pkgs" IN_NIX_RUN=1 nix "$subcommand" "$@" --command "$which_shell"
 }
 fns "$@"

--- a/bin/any-nix-shell
+++ b/bin/any-nix-shell
@@ -12,9 +12,8 @@ end
 
 # Overwrite the nix command
 function nix
-    if test \$argv[1] = shell
-        set argv[1] fish
-        $(which .any-nix-wrapper) \$argv
+    if test \$argv[1] = run
+        $(which .any-nix-wrapper) fish \$argv
     else
         command nix \$argv
     end
@@ -51,8 +50,7 @@ function nix-shell () {
 
 # Overwrite the nix command
 function nix () {
-    if [[ \$1 == shell ]]; then
-        shift
+    if [[ "\$1" == "run" ]]; then
         $(which .any-nix-wrapper) zsh "\$@"
     else
         command nix "\$@"


### PR DESCRIPTION
`nix shell` didn't exist from Nix 2.0 to 2.3. And in 2.4 it keeps the shell, anyways, so any-nix-shell is not required.

Fixes #10