### PR TITLE
fix formatting of complex expressions by stopping at first white space

### DIFF
--- a/bin/.any-nix-shell-wrapper
+++ b/bin/.any-nix-shell-wrapper
@@ -24,7 +24,12 @@ fns () {
                 pkg=1
             fi
         elif [[ $pkg == 1 ]]; then
-            pkgs+=" "$arg
+            arg="$(printf "$arg" | xargs)" # trims all words
+            truncated=$(printf "$arg" | head -n1 | cut -d' ' -f1)
+            pkgs+=" "$truncated
+            if [[ $truncated != $arg ]]; then
+                pkgs+=...
+            fi
         fi
     done
     if [[ -n $name ]] && [[ $name != shell ]]; then

--- a/bin/.any-nix-wrapper
+++ b/bin/.any-nix-wrapper
@@ -28,7 +28,12 @@ fns () {
                 pos=1
             fi
         else
-            pkgs+=" "$arg
+            arg="$(printf "$arg" | xargs)" # trims all words
+            truncated=$(printf "$arg" | head -n1 | cut -d' ' -f1)
+            pkgs+=" "$truncated
+            if [[ $truncated != $arg ]]; then
+                pkgs+=...
+            fi
         fi
     done
     if [[ -n $name ]] && [[ $name != shell ]]; then


### PR DESCRIPTION
For instance, if right prompt is enabled,

```nix
nix-shell -p "(python.withPackages(ps: []))"
```

now shows the right prompt `(python.withPackages(ps:...`

Fixes #1