### PR TITLE
Add support for the 'nix develop' command

### DIFF
--- a/bin/.any-nix-wrapper
+++ b/bin/.any-nix-wrapper
@@ -9,7 +9,7 @@ fns () {
     pos=0
 
     # `nix run` only launched a shell from Nix 2.0.* to 2.3.*
-    if nix --version | grep -vq ' 2\.[0-3][^0-9]'; then
+    if [[ "$subcommand" == "run" ]] && nix --version | grep -vq ' 2\.[0-3][^0-9]'; then
         exec nix "$subcommand" "$@"
     fi
 

--- a/bin/any-nix-shell
+++ b/bin/any-nix-shell
@@ -10,7 +10,7 @@ aliases["nix-shell"] = "@(\$(which .any-nix-shell-wrapper)) xonsh @(\$args)"
 
 # Overwrite the nix command
 def __nix(args):
-    if args and args[0] == "run":
+    if args and ( args[0] == "run" or args[0] == "develop" ):
         @(\$(which .any-nix-wrapper)) xonsh @(args)
     else:
         @(\$(which -s nix)) @(args)
@@ -44,7 +44,7 @@ end
 
 # Overwrite the nix command
 function nix
-    if test \$argv[1] = run
+    if test \$argv[1] = run or test \$argv[1] = develop
         $(which .any-nix-wrapper) fish \$argv
     else
         command nix \$argv
@@ -82,7 +82,7 @@ function nix-shell () {
 
 # Overwrite the nix command
 function nix () {
-    if [[ "\$1" == "run" ]]; then
+    if [[ "\$1" == "run" ]] || [[ "\$1" == "develop" ]]; then
         $(which .any-nix-wrapper) zsh "\$@"
     else
         command nix "\$@"


### PR DESCRIPTION
This PR is based on the fork mentioned in #30. I chose to make a separate fork instead of using @manuelbb-upb 's fork since theirs included a flake, which doesn't seem necessary to implement this feature. I tested by overriding the `nixpkgs` version like so:

```nix
  any-nix-shell = pkgs.any-nix-shell.overrideAttrs {
    src = inputs.any-nix-shell-with-develop;
  };
```

where `inputs.any-nix-shell-with-develop` is from my flake inputs:

```nix
{
  inputs = {
    any-nix-shell-with-develop = {
      url = "github:calebstewart/any-nix-shell/add-nix-develop-support";
      flake = false;
    };
  };
}
```

I use `zsh`, and don't know/use the other shells supported here much or at all, so this has only been tested in `zsh`.