### PR TITLE
Correct instructions for fish on NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To do so, add the following to your configuration (*/etc/nixos/configuration.nix
 ```nix
 {
   programs.fish.enable = true;
-  programs.fish.promptInit = ''
+  programs.fish.interactiveShellInit = ''
     ${pkgs.any-nix-shell}/bin/any-nix-shell fish --info-right | source
   '';
 }


### PR DESCRIPTION
The promptInit option is now deprecated and generates the following error:

```
The option definition `programs.fish.promptInit' in `(path)' no longer has any effect; please remove it.
       Prompt is now configured through the

         programs.fish.interactiveShellInit

       option. Please change to use that instead.
```